### PR TITLE
:recycle: update Docker Image CI action

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,11 +1,9 @@
 name: Docker Image CI
 
 on:
-  workflow_run:
-    workflows: ["Ruby on Rails CI"]
-    branches: [main]
-    types: 
-      - completed
+  push:
+    tags:        
+      - 'v*'
 
 jobs:
 
@@ -31,7 +29,7 @@ jobs:
       env:
         ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         ECR_REPOSITORY: cloud-ops-admins/cloudopsbot-prod-ecr
-        IMAGE_TAG: 0.1.0
+        IMAGE_TAG: ${{ github.ref }}
       run: |
         docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
         docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG


### PR DESCRIPTION
**Changes:**
- update the action trigger to 'on push' for 'tags'
- docker image will be build only when a tag is pushed and the image will be tagged with the github tag before pushing it to AWS ECR  

**Why**
- this change will reduce the number of images are pushed to the ECR.