### PR TITLE
🩹 use Chart AppVersion as image tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,34 @@ Available `Makefile` targets:
 - `Make run`  
 - `Make test`  
 
-If you wish to run the kubernetes deployment, populate the below values in the `.env` file:  
+## Remote Deployment  
+
+If you wish to release another Helm Chart upgrade to the k8s cluster in Cloud Platform, please follow the steps below:  
+
+- Step :one: : Follow the [Cloud Platform guide](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/kubectl-config.html#how-to-use-kubectl-to-connect-to-the-cluster) to authenticate and configure your local `kubectl` to connect to the cluster.  
+
+
+- Step :two: : Populate the below values in the `.env` file:  
 
 ```
 ECR_URL= <can be found in the kubernetes secrets>
 SECRET_KEY_BASE= #generate one by: openssl rand -base64 32
+```  
+
+Follow the [Cloud Platform guide](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/ecr-setup.html#accessing-the-credentials) to read secrets in kubernetes.  
+
+
+- Step :three: : Update the appVersion value of the chart in `cloudopsbot/Chart.yaml` file to the appropriate values (an example: `v1.0.1`). Run the below command to get a list of available tags:  
+
 ```
+git tag
+```  
+
+- Step :four: : use the below Makefile target to release a Helm chart upgrade:  
+
+```
+make deploy
+```  
 
 ## Features :sparkles:  
 

--- a/cloudopsbot/Chart.yaml
+++ b/cloudopsbot/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 1.0.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.16.0"
+appVersion: "v1.0.3"

--- a/cloudopsbot/templates/deployment.yaml
+++ b/cloudopsbot/templates/deployment.yaml
@@ -31,7 +31,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ trimPrefix "v" .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: RACK_ENV

--- a/cloudopsbot/values.yaml
+++ b/cloudopsbot/values.yaml
@@ -7,8 +7,6 @@ replicaCount: 1
 image:
   repository: ""
   pullPolicy: IfNotPresent
-  # Overrides the image tag whose default is the chart appVersion.
-  tag: 0.1.0
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
developers will need to update the `Chart AppVersion` to the latest or any other available GitHub `tags` before executing another helm chart upgrade.