### PR TITLE
:sparkles: add new git actions

### DIFF
--- a/.github/workflows/issue-to-project.yml
+++ b/.github/workflows/issue-to-project.yml
@@ -1,0 +1,16 @@
+name: Add issues to project
+
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@main
+        with:
+          project-url: https://github.com/orgs/ministryofjustice/projects/11
+          github-token: ${{ secrets.TECH_SERVICES_GITHUB_TOKEN }}

--- a/.github/workflows/jira-issue-creation.yml
+++ b/.github/workflows/jira-issue-creation.yml
@@ -1,0 +1,22 @@
+on:
+  issues:
+    types:
+      - opened
+
+name: Jira Issue Creation Demo
+jobs:
+  jiraIssueCreation:
+    name: Jira Issue Creation Demo
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Jira Creation Demo
+        uses: bryannice/gitactions-jira-issue-creation@master
+        env:
+          JIRA_ACCOUNT_URL: https://dsdmoj.atlassian.net/
+          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN_AR }}
+          JIRA_ISSUE_DESCRIPTION: Demo'ing Jira Issue Creation
+          JIRA_ISSUE_SUMMARY: Demo'ing Jira Issue Creation
+          JIRA_ISSUE_TYPE: Story
+          JIRA_PROJECT: PTTP
+          JIRA_USERNAME: aaron.robinson1@justice.gov.uk


### PR DESCRIPTION
Testing GitHub Actions...

Automatically adds issues to the CloupsOps GitHub project board and Jira PTTP board.