### PR TITLE
🚧 Add Service Now Incident Functionality 

### DIFF
--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -27,6 +27,8 @@ jobs:
       DATABASE_URL: "postgres://rails:password@localhost:5432/rails_test"
       SLACK_SIGNING_SECRET: ${{ secrets.SLACK_SIGNING_SECRET }}
       SLACK_OAUTH_TOKEN: ${{ secrets.SLACK_OAUTH_TOKEN }}
+      SNOW_BASIC_AUTH_USERNAME: ${{ secrets.SNOW_BASIC_AUTH_USERNAME }}
+      SNOW_BASIC_AUTH_PASSWORD: ${{ secrets.SNOW_BASIC_AUTH_PASSWORD }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@
 /.byebug_history
 /config/local_env.yml
 /.env
+
+.vscode

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ serve: stop start-db
 
 run: serve
 
-test: stop start-db
+test: stop build start-db
 	docker-compose run --rm app bundle exec rake
 
 stop:

--- a/app/controllers/slack_controller.rb
+++ b/app/controllers/slack_controller.rb
@@ -127,7 +127,7 @@ class SlackController < ApplicationController
     https = Net::HTTP.new(uri.host, uri.port)
     https.use_ssl = true
     request = Net::HTTP::Post.new(uri.request_uri, header)
-    request.basic_auth ENV['SNOW_BASIC_AUTH_USERNAME'], ENV['SNOW_BASIC_AUTH_PASSWORD']
+    #request.basic_auth ENV['SNOW_BASIC_AUTH_USERNAME'], ENV['SNOW_BASIC_AUTH_PASSWORD']
     request.basic_auth {{ secrets.SNOW_BASIC_AUTH_USERNAME }}, {{ secrets.SNOW_BASIC_AUTH_PASSWORD }}
     request.body = incident.to_json
 

--- a/app/controllers/slack_controller.rb
+++ b/app/controllers/slack_controller.rb
@@ -132,6 +132,7 @@ class SlackController < ApplicationController
     request.body = incident.to_json
 
     response = https.request(request)
+    p ENV['SNOW_BASIC_AUTH_USERNAME']
     p response.body
     JSON.parse(response.body)['result']['incident_number']
   end

--- a/app/controllers/slack_controller.rb
+++ b/app/controllers/slack_controller.rb
@@ -1,5 +1,10 @@
 class SlackController < ApplicationController
 
+  require 'net/http'
+  require 'net/https'
+  require 'uri'
+  require 'json'
+
   before_action :verify_slack_signature, only: [:events]
 
   def index
@@ -42,7 +47,6 @@ class SlackController < ApplicationController
     hex_hash = OpenSSL::HMAC.hexdigest(digest, signing_secret, sig_basestring)
     computed_signature = [version_number, hex_hash].join('=')
     slack_signature = request.headers['X-Slack-Signature']
-
     if computed_signature != slack_signature
       render nothing: true, status: :unauthorized
     end
@@ -100,6 +104,11 @@ class SlackController < ApplicationController
         render plain: "No registered users in this channel.", status: :ok
         HTTP.auth("Bearer #{ENV['SLACK_OAUTH_TOKEN']}").post("https://slack.com/api/chat.postMessage", :json => {"channel":channel,"text":":robot_face: :speech_balloon: No registered users in this channel."})
       end
+    when /incident/
+      post_incident_to_service_now
+      incident_number = post_incident_to_service_now
+      render plain: "Hey, incident #{incident_number} created!!!", status: :ok
+      HTTP.auth("Bearer #{ENV['SLACK_OAUTH_TOKEN']}").post("https://slack.com/api/chat.postMessage", :json => {"channel":channel,"text":"Hey #{incident_number} created!!!"})
     end
     
   end
@@ -109,4 +118,20 @@ class SlackController < ApplicationController
     HTTP.auth("Bearer #{ENV['SLACK_OAUTH_TOKEN']}").post("https://slack.com/api/chat.postMessage", :json => {"channel":channel,"text":":robot_face: :speech_balloon:  Hi <@#{user}>, Welcome to the channel... I guess. \n \n I'm your not-so-trustworthy CloudOpsBot. If you want to know what I can do, send a message like this into the channel: \n \n @CloudOpsBot help "})
   end
 
+  def post_incident_to_service_now    
+    uri = URI.parse("https://mojpreprod.service-now.com/api/moju2/cloud_ops/create_incident")
+    payload = File.read("incident.json")
+    incident = JSON.parse(payload)
+
+    header = {'Content-Type': 'application/json'}
+    https = Net::HTTP.new(uri.host, uri.port)
+    https.use_ssl = true
+    request = Net::HTTP::Post.new(uri.request_uri, header)
+    request.basic_auth ${{ secrets.SNOW_BASIC_AUTH_USERNAME }}, ${{ secrets.SNOW_BASIC_AUTH_PASSWORD }}
+    request.body = incident.to_json
+
+    response = https.request(request)
+    response_parse = JSON.parse(response.body)
+    incident_number = response_parse['result']['incident_number']
+  end
 end

--- a/app/controllers/slack_controller.rb
+++ b/app/controllers/slack_controller.rb
@@ -127,13 +127,11 @@ class SlackController < ApplicationController
     https = Net::HTTP.new(uri.host, uri.port)
     https.use_ssl = true
     request = Net::HTTP::Post.new(uri.request_uri, header)
-    #request.basic_auth ENV['SNOW_BASIC_AUTH_USERNAME'], ENV['SNOW_BASIC_AUTH_PASSWORD']
-    request.basic_auth {{ secrets.SNOW_BASIC_AUTH_USERNAME }}, {{ secrets.SNOW_BASIC_AUTH_PASSWORD }}
+    request.basic_auth ENV['SNOW_BASIC_AUTH_USERNAME'], ENV['SNOW_BASIC_AUTH_PASSWORD']
     request.body = incident.to_json
 
     response = https.request(request)
-    p {{ secrets.SNOW_BASIC_AUTH_USERNAME }}
-    p response.body
+
     JSON.parse(response.body)['result']['incident_number']
   end
 end

--- a/app/controllers/slack_controller.rb
+++ b/app/controllers/slack_controller.rb
@@ -128,10 +128,11 @@ class SlackController < ApplicationController
     https.use_ssl = true
     request = Net::HTTP::Post.new(uri.request_uri, header)
     request.basic_auth ENV['SNOW_BASIC_AUTH_USERNAME'], ENV['SNOW_BASIC_AUTH_PASSWORD']
+    #request.basic_auth {{ secrets.SNOW_BASIC_AUTH_USERNAME }}, {{ secrets.SNOW_BASIC_AUTH_PASSWORD }}
     request.body = incident.to_json
 
     response = https.request(request)
-
+    p response.body
     JSON.parse(response.body)['result']['incident_number']
   end
 end

--- a/app/controllers/slack_controller.rb
+++ b/app/controllers/slack_controller.rb
@@ -128,11 +128,11 @@ class SlackController < ApplicationController
     https.use_ssl = true
     request = Net::HTTP::Post.new(uri.request_uri, header)
     request.basic_auth ENV['SNOW_BASIC_AUTH_USERNAME'], ENV['SNOW_BASIC_AUTH_PASSWORD']
-    #request.basic_auth {{ secrets.SNOW_BASIC_AUTH_USERNAME }}, {{ secrets.SNOW_BASIC_AUTH_PASSWORD }}
+    request.basic_auth {{ secrets.SNOW_BASIC_AUTH_USERNAME }}, {{ secrets.SNOW_BASIC_AUTH_PASSWORD }}
     request.body = incident.to_json
 
     response = https.request(request)
-    p ENV['SNOW_BASIC_AUTH_USERNAME']
+    p {{ secrets.SNOW_BASIC_AUTH_USERNAME }}
     p response.body
     JSON.parse(response.body)['result']['incident_number']
   end

--- a/app/controllers/slack_controller.rb
+++ b/app/controllers/slack_controller.rb
@@ -64,7 +64,7 @@ class SlackController < ApplicationController
       HTTP.auth("Bearer #{ENV['SLACK_OAUTH_TOKEN']}").post("https://slack.com/api/chat.postMessage", :json => {"channel":channel,"thread_ts":ts,"text":":robot_face: :speech_balloon: Hi <@#{user}>, your test was successful. :tada:"})
     when /help/
       render plain: "Hi <@#{user}>, here's some help.", status: :ok
-      HTTP.auth("Bearer #{ENV['SLACK_OAUTH_TOKEN']}").post("https://slack.com/api/chat.postMessage", :json => {"channel":channel,"thread_ts":ts,"text": ":coffee: :robot_face: :smoking: \n \n Hi <@#{user}>, you need help? :flushed: Pfft! Alright. \n \n Mention me, @CloudOpsBot, in your message, in the channel, with the following commands... \n \n • 'Register' registers you to the channel the command is ran in. \n • 'Select' selects a registered user in the current channel. \n • 'Deregister' deregisters you from the channel. \n • 'List' List all registered Users in the current channel.  \n • 'Help' Come on, how did you get here in the first place?!" })
+      HTTP.auth("Bearer #{ENV['SLACK_OAUTH_TOKEN']}").post("https://slack.com/api/chat.postMessage", :json => {"channel":channel,"thread_ts":ts,"text": ":coffee: :robot_face: :smoking: \n \n Hi <@#{user}>, you need help? :flushed: Pfft! Alright. \n \n Mention me, @CloudOpsBot, in your message, in the channel, with the following commands... \n \n • 'Register' registers you to the channel the command is ran in. \n • 'Select' selects a registered user in the current channel. \n • 'Deregister' deregisters you from the channel. \n • 'List' List all registered Users in the current channel. \n • 'incident <incident description>' Creates an incident in Service Now with all text following the word 'incident' becoming the incident description. \n • 'Help' Come on, how did you get here in the first place?!" })
     when /deregister/
       the_user = User.find_by(slack_handle: user, channel_handle: channel)
       if the_user
@@ -108,7 +108,7 @@ class SlackController < ApplicationController
       incident_title = message.match(/incident\s(.+)/).captures.first
       incident_number = post_incident_to_service_now(incident_title) 
       render plain: "Hey, incident #{incident_number} created!!!", status: :ok
-      HTTP.auth("Bearer #{ENV['SLACK_OAUTH_TOKEN']}").post("https://slack.com/api/chat.postMessage", :json => {"channel":channel,"text":"Hey #{incident_number} created!!!"})
+      HTTP.auth("Bearer #{ENV['SLACK_OAUTH_TOKEN']}").post("https://slack.com/api/chat.postMessage", :json => {"channel":channel,"text":":robot_face: :speech_balloon: *#{incident_number}* - _'#{incident_title}'_ - has been created in Service Now."})
     end
   end
 

--- a/cloudopsbot/Chart.yaml
+++ b/cloudopsbot/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.1
+version: 1.0.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.0.5"
+appVersion: "v1.0.6"

--- a/fixtures/incident.json
+++ b/fixtures/incident.json
@@ -1,0 +1,12 @@
+{
+  "caller_id": "f94087c21b24cd10e9e9ffb7d34bcbcf",
+  "u_moj_estate": "adee4828dbc2bb081b4ffc45ae9619fa",
+  "contact_type": "Atos Auto-Ticketing",
+  "category": "software",
+  "subcategory": "configuration",
+  "service_offering": "04e8326fdbc2af0096907cbdae9619e7",
+  "cmdb_ci": "abaa31091bc78410299cdc6fbd4bcbf3",
+  "impact": "2",
+  "assignment_group": "eef0d119dbdf63407667fc45ae96191b",
+  "short_description": "Completely different incident!"
+}

--- a/spec/lib/data/app_mention_incident.json
+++ b/spec/lib/data/app_mention_incident.json
@@ -5,7 +5,7 @@
   "event": {
     "client_msg_id": "61763119-5031-4f1d-9bd6-2f30336ae0f4",
     "type": "app_mention",
-    "text": "<@U03055Z254L> incident",
+    "text": "<@U03055Z254L> incident Civil Servants ran out of cheese!",
     "user": "U029KDGBGNT",
     "ts": "1643300259.367729",
     "team": "T02DYEB3A",

--- a/spec/lib/data/app_mention_incident.json
+++ b/spec/lib/data/app_mention_incident.json
@@ -1,0 +1,50 @@
+{
+  "token": "[FILTERED]",
+  "team_id": "T02DYEB3A",
+  "api_app_id": "A02SZ45FL9Z",
+  "event": {
+    "client_msg_id": "61763119-5031-4f1d-9bd6-2f30336ae0f4",
+    "type": "app_mention",
+    "text": "<@U03055Z254L> incident",
+    "user": "U029KDGBGNT",
+    "ts": "1643300259.367729",
+    "team": "T02DYEB3A",
+    "blocks": [
+      {
+        "type": "rich_text",
+        "block_id": "4Ou/",
+        "elements": [
+          {
+            "type": "rich_text_section",
+            "elements": [
+              {
+                "type": "user",
+                "user_id": "U03055Z254L"
+              },
+              {
+                "type": "text",
+                "text": " incident"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "channel": "C02TNSV394Y",
+    "event_ts": "1643300259.367729"
+  },
+  "type": "event_callback",
+  "event_id": "Ev030H8CDEAE",
+  "event_time": 1643300259,
+  "authorizations": [
+    {
+      "enterprise_id": "",
+      "team_id": "T02DYEB3A",
+      "user_id": "U03055Z254L",
+      "is_bot": true,
+      "is_enterprise_install": false
+    }
+  ],
+  "is_ext_shared_channel": false,
+  "event_context": "4-eyJldCI6ImFwcF9tZW50aW9uIiwidGlkIjoiVDAyRFlFQjNBIiwiYWlkIjoiQTAyU1o0NUZMOVoiLCJjaWQiOiJDMDJUTlNWMzk0WSJ9"
+}

--- a/spec/requests/slack_spec.rb
+++ b/spec/requests/slack_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe "Slack", type: :request do
     end
 
     it "verifies and responds with the 'new incident created' message when slack sends a string 'incident' app mention request from a channel and user is registered" do
-      headers = { "X-Slack-Request-Timestamp" => "1642698248", "X-Slack-Signature" => "v0=2aec3edd38a73c8e968cc87c1db6ce5773273a8cea68c75cb9c7ca569820f3c7" }
+      headers = { "X-Slack-Request-Timestamp" => "1642698248", "X-Slack-Signature" => "v0=d2abdae9037eb85ae21c30573f7e554da2859350818eec145024c9658d2f0d4f" }
       post "/slack/events", :params => { :slack => JSON.parse(File.read("./spec/lib/data/app_mention_incident.json")) }, :headers => headers
       expect(response).to have_http_status(:success)
       expect(response.body).to include("INC")

--- a/spec/requests/slack_spec.rb
+++ b/spec/requests/slack_spec.rb
@@ -96,6 +96,13 @@ RSpec.describe "Slack", type: :request do
       expect(User.count).to eq 0
     end
 
+    it "verifies and responds with the 'new incident created' message when slack sends a string 'incident' app mention request from a channel and user is registered" do
+      headers = { "X-Slack-Request-Timestamp" => "1642698248", "X-Slack-Signature" => "v0=2aec3edd38a73c8e968cc87c1db6ce5773273a8cea68c75cb9c7ca569820f3c7" }
+      post "/slack/events", :params => { :slack => JSON.parse(File.read("./spec/lib/data/app_mention_incident.json")) }, :headers => headers
+      expect(response).to have_http_status(:success)
+      expect(response.body).to include("INC")
+      expect(User.count).to eq 0
+    end
   end
 
 end


### PR DESCRIPTION
This PR adds new @ mention functionality for the string 'incident'. 

When a user mentions the bot - `@CloudOpsBot incident` in Slack - the bot creates a new incident and returns a message stating the newly created incidents number.

The new `post_incident_to_service_now` method in the slack_controller uses GitHub repository secrets:
- `SNOW_BASIC_AUTH_USERNAME`
- `SNOW_BASIC_AUTH_PASSWORD`

These are currently valid for Pre-Production

🚧 Future development needs to be done to:
- potentially return a hyperlink in the message to save the user searching for the incident
- add the ability to specify variables in the mention to the bot, for example `@CloudOpsBot incident <title> <description>`
- testing should be improved as the rspec is currently only confirming the string `INC` is included in the response from the controller 

If this PR is merged work this will not take effect on the bot until deployment changes listed in the wiki are completed (tagging etc).